### PR TITLE
Avoid asn1crypto and oscrypto use newest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     url='https://github.com/bbits/cloak-server',
 
     install_requires=[
-        'asn1crypto>=0.21.0',
+        'asn1crypto>=0.21.0,<1.0.0',
         'csrbuilder>=0.10.1',
         'oscrypto>=0.18.0',
         'requests>=2.5.1',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         'asn1crypto>=0.21.0,<1.0.0',
         'csrbuilder>=0.10.1',
-        'oscrypto>=0.18.0',
+        'oscrypto>=0.18.0,<1.0.0',
         'requests>=2.5.1',
         'six>=1.10.0',
         'typing',


### PR DESCRIPTION
This solves an issue with newer versions of asn1crypto and oscrypto. Avoids to install versions 1.0.0+